### PR TITLE
fix aborted xhr json error

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -217,7 +217,9 @@ function Ajax(params) {
 			return;
 		}
 
-		if (_params.type === 'json' && typeof _xhr.response === 'string') {
+		if (_params.type === 'json' &&
+			_xhr.response &&
+			typeof _xhr.response === 'string') {
 			response = JSON.parse(_xhr.response);
 		} else {
 			response = _xhr.response;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "babel-core": "5.8.25",
-    "babel-eslint": "4.1.3",
+    "babel-eslint": "4.1.7",
     "babel-loader": "5.3.2",
     "babel-runtime": "^5.8.25",
     "chai": "^3.3.0",


### PR DESCRIPTION
- response is empty string when request is aborted, so `JSON.parse` throws an error.
- use babel-eslint 4.1.7 to fix `visitClass` error ([issue](https://github.com/babel/babel-eslint/issues/243))
