### PR TITLE
pass an option to the ajax class to allow the setting of cookies

### DIFF
--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -129,6 +129,10 @@ function xhr(options) {
 		} : createStandardXHR;
 	_ret = _ret();
 
+	if(options.withCredentials == true){
+		_ret.withCredentials = true;
+	}
+
 	/* istanbul ignore next: jsonp is too crazy */
 	if (!_ret || (crossDomain &&
 		typeof _ret.withCredentials === 'undefined') ||

--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -129,7 +129,7 @@ function xhr(options) {
 		} : createStandardXHR;
 	_ret = _ret();
 
-	if (options.withCredentials == true) {
+	if (options.withCredentials === true) {
 		_ret.withCredentials = true;
 	}
 

--- a/lib/ajax.js
+++ b/lib/ajax.js
@@ -129,7 +129,7 @@ function xhr(options) {
 		} : createStandardXHR;
 	_ret = _ret();
 
-	if(options.withCredentials == true){
+	if (options.withCredentials == true) {
 		_ret.withCredentials = true;
 	}
 


### PR DESCRIPTION
when using the ajax library in es6 branch, it's not sending cookies.  This generally isn't needed with json web tokens, but in some frameworks you must send a cookie to get your first jwt.  This allows an optional flag to be set in the constructor that permits cookie usage.
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials
